### PR TITLE
typos and strict hint fixes

### DIFF
--- a/Game/Levels/AdvancedFunctionWorld/L03_CancelingSurjectivity.lean
+++ b/Game/Levels/AdvancedFunctionWorld/L03_CancelingSurjectivity.lean
@@ -7,7 +7,7 @@ Title "Canceling Surjectivity"
 
 Introduction "Recall that a function `f : A → B` is *surjective* if for every `b : B` there exists some `x : A` so that `f x = b`.
 
-In the level, we will consider a composable pair of functions `f : A → B` and `g : B → C`.
+In this level, we will consider a composable pair of functions `f : A → B` and `g : B → C`.
 
 We will show that if the composite `g ∘ f : A → C` is surjective, then the function `g : B → C` is surjective too.
 "

--- a/Game/Levels/AdvancedFunctionWorld/L05_Injectivity.lean
+++ b/Game/Levels/AdvancedFunctionWorld/L05_Injectivity.lean
@@ -9,7 +9,7 @@ Introduction "Recall that every function is *well-defined*. For any function `f 
 
 A function `f : A → B` is *injective* if for every `x y : A`, `f x = f y` implies `x = y`.
 
-This condition says that any output element of `f` has a unique corresponding input. Note it is not necessary that any element of `B` is an output of an injective function. Instead, injectivity asserts that if two elements of `A` have the same output, then those elements must be equal.
+This condition says that any output element of `f` has a unique corresponding input. Note that it is not necessary that any element of `B` is an output of an injective function. Instead, injectivity asserts that if two elements of `A` have the same output, then those elements must be equal.
 
 Unlike well-definedness, the statement `∀ x y : A, f x = f y → x = y` is true for some functions `f` but false for others.
 

--- a/Game/Levels/AdvancedFunctionWorld/L15_BossLevel.lean
+++ b/Game/Levels/AdvancedFunctionWorld/L15_BossLevel.lean
@@ -9,9 +9,11 @@ Introduction "Using function extensionality, we can give a third logically equiv
 
 A function `f : A → B` is an *isomorphism* if there exists a function `g : B → A` so that `g ∘ f = id` and `f ∘ g = id`.
 
-The first equation is between functions from `A` to `A`. By function extensionality, it is equivalent to the condition that `∀ a : A, g (f a)`.
+The first equation is between functions from `A` to `A`. By function extensionality, it is
+equivalent to the condition that `∀ a : A, g (f a) = a`.
 
-The second equation is between functions from `B` to `B`. By function extensionality, it is equivalent to the condition that `∀ b : B, f (g a)`.
+The second equation is between functions from `B` to `B`. By function extensionality, it is
+equivalent to the condition that `∀ b : B, f (g b) = b`.
 
 In Lean, isomorphisms of types are also called *equivalences*, perhaps acknowledging a newly discovered connection between dependent type theory and homotopy theory.
 

--- a/Game/Levels/BooleanWorld/L03_Conjunction.lean
+++ b/Game/Levels/BooleanWorld/L03_Conjunction.lean
@@ -31,7 +31,8 @@ Statement (preamble := refine let f := ?f; ⟨f, ?eq⟩) :
   -- now prove that you defined the right thing
   exact ⟨rfl, rfl, rfl, rfl⟩
 
-Conclusion "Was it necessary to consider all four cases of two boolean elements or can you define this function by considering fewer cases? If using the tactic `match`, try replacement one of the input booleans with `_` to indicate that the value does not matter. The function `and` is now in your library."
+Conclusion "Was it necessary to consider all four cases of two boolean elements or can you define
+this function by considering fewer cases? If using the tactic `match`, try replacing one of the input booleans with `_` to indicate that the value does not matter. The function `and` is now in your library."
 
 /-- The function `and : Bool → Bool → Bool` captures the logical operation of conjunction. -/
 DefinitionDoc Bool.and as "and" in "Bool"

--- a/Game/Levels/BooleanWorld/L06_DisjunctionSymmetry.lean
+++ b/Game/Levels/BooleanWorld/L06_DisjunctionSymmetry.lean
@@ -13,7 +13,7 @@ Note Lean has an alternate notation `x || y` for `or x y`.
 /-- The function `or : Bool → Bool → Bool` is symmetric. -/
 Statement (x y : Bool) : or x y = or y x := by
   Hint (hidden := true) "Recall `cases h : {x}` and `cases k :
-  cases {y}` may make it clearer which cases are which."
+  {y}` may make it clearer which cases are which."
   cases x <;> cases y <;> rfl
 
 Conclusion "This proof can be written in one line as `cases x <;> cases y <;> rfl` where the `<;>` means &ldquo;do the following in all cases&rdquo;."

--- a/Game/Levels/BooleanWorld/L08_NotEqual.lean
+++ b/Game/Levels/BooleanWorld/L08_NotEqual.lean
@@ -29,9 +29,9 @@ Alternatively, type `exact Bool.noConfusion` to solve this level with Lean's bui
 Statement : ¬ (false = true) := by
   Hint (hidden := true) "Start with `intro p`."
   intro p
-  Hint (hidden := true) "Define a function `Bool → Prop` by `let P : Bool → Prop := by intro b ; match b with | false => exact False | true => exact True`."
+  Hint (strict:=true) (hidden := true) "Define a function `Bool → Prop` by `let P : Bool → Prop := by intro b ; match b with | false => exact False | true => exact True`."
   let P : Bool → Prop := by intro b ; match b with | false => exact False | true => exact True
-  Hint (hidden := true) "Define a function `P true → P false` by `let tr : P true → P false := by intro x ; rw [p] ; exact x
+  Hint (strict:=true) (hidden := true) "Define a function `P true → P false` by `let tr : P true → P false := by intro x ; rw [p] ; exact x
  `. In editor mode, start with `let tr : P true → P false := by` then continue with each of the three tactics on three subsequent lines. This way you can see how the goal evolves with each step in the construction."
   let tr : P true → P false := by intro x ; rw [p] ; exact x
   Hint (hidden := true) "By the definition of the family of propositions `P : Bool → Prop`, the function `tr : P true → P false` is a function `tr : True → False`. In particular, if we apply `tr` to an element of `True`, we get an element of `False`, which is what we want."

--- a/Game/Levels/ClassicalWorld.lean
+++ b/Game/Levels/ClassicalWorld.lean
@@ -45,5 +45,5 @@ This permits a proof strategy called *proof by contradiction*. If the goal is to
 * Then use the assumption `¬ P` to derive a contradiction, thus constructing a proof of `¬ ¬ P`.
 * Finally, apply the implication `¬ ¬ P → P` to convert the proof of `¬ ¬ P` into a proof of `P`.
 
-In fact, as statements concerning arbitrary propositions, the law of exluded middle and double negation elimination are equivalent &mdash; even constructively &mdash; as we will show in the Boss Level of this world.
+In fact, as statements concerning arbitrary propositions, the law of excluded middle and double negation elimination are equivalent &mdash; even constructively &mdash; as we will show in the Boss Level of this world.
 "

--- a/Game/Levels/ClassicalWorld/L01_ByContradiction.lean
+++ b/Game/Levels/ClassicalWorld/L01_ByContradiction.lean
@@ -34,7 +34,9 @@ Statement {P : Prop} : ¬ ¬ P → P := by
 
 end
 
-Conclusion "Lean has a built-in name `Classical.byContradiction : ¬ ¬ P → P` for this implication, which is also called *double negation elimination*. In the source files for Classical World, we have told that we want to use classical reasoning (by opening the `Classical` namespace), which is why typing `exact byContradiction` suffices to solve this level."
+Conclusion "Lean has a built-in name `Classical.byContradiction : ¬ ¬ P → P` for this implication,
+which is also called *double negation elimination*. In the source files for Classical World, we have
+told Lean that we want to use classical reasoning (by opening the `Classical` namespace), which is why typing `exact byContradiction` suffices to solve this level."
 
 TheoremTab "Classical"
 

--- a/Game/Levels/DependentWorld/L04_Pairs.lean
+++ b/Game/Levels/DependentWorld/L04_Pairs.lean
@@ -17,7 +17,8 @@ Your task in this level is to define both projection functions from the dependen
 
 The first of these defines an ordinary function from the type `(x : A) × B x` to the type `A`.
 
-The second of these defines a dependent function mapping out of type type `(x : A) × B x`. The reason the second project is a *dependent* function is that its output type depends on the input element `p : (x : A) × B x`.
+The second of these defines a dependent function mapping out of type `(x : A) × B x`. The reason the
+second projection is a *dependent* function is that its output type depends on the input element `p : (x : A) × B x`.
 
 Note that for `p : (x : A) × B x`, we have `rfl : p = ⟨p.1, p.2⟩`.
 "

--- a/Game/Levels/NegationWorld/L01_ExFalso.lean
+++ b/Game/Levels/NegationWorld/L01_ExFalso.lean
@@ -22,7 +22,7 @@ Statement {P : Prop} : False → P := by
   Hint (hidden := true) "Type `cases {p}` to ask Lean to consider all possible cases involving a proof of false. As there are no cases, this will complete the proof."
   cases p
 
-Conclusion "Lean has a built-in name `False.elim : Empty → P` for the theorem you have just proven. Thus `exact False.elim` will also solve this level. This theorem has been added to the library."
+Conclusion "Lean has a built-in name `False.elim : False → P` for the theorem you have just proven. Thus `exact False.elim` will also solve this level. This theorem has been added to the library."
 
 TheoremTab "False"
 

--- a/Game/Levels/QuantifierWorld/L02_MoreTransitivity.lean
+++ b/Game/Levels/QuantifierWorld/L02_MoreTransitivity.lean
@@ -33,4 +33,4 @@ Statement {A : Type} : ∀ w x y z : A, w = x → x = y → y = z → w = z := b
   rw [p, q, r]
   rfl
 
-Conclusion "In general families of propositions indexed by multiple variables are just functions with multiple input types valued in `Prop`, such as `P : A → B → C → Prop`."
+Conclusion "In general, families of propositions indexed by multiple variables are just functions with multiple input types valued in `Prop`, such as `P : A → B → C → Prop`."


### PR DESCRIPTION
This PR fixes typos and adds strict hints for hints that tell the user to use `let` or `have` preventing the hint from appearing again after that step.